### PR TITLE
fixed coredump of use-after-free request

### DIFF
--- a/ngx_http_proxy_connect_module.c
+++ b/ngx_http_proxy_connect_module.c
@@ -668,6 +668,7 @@ ngx_http_proxy_connect_write_upstream(ngx_http_request_t *r,
 
     if (!ctx->send_established) {
         ngx_http_proxy_connect_send_connection_established(r);
+        return;
     }
 
     if (!ctx->send_established_done) {

--- a/ngx_http_proxy_connect_module.c
+++ b/ngx_http_proxy_connect_module.c
@@ -378,8 +378,9 @@ ngx_http_proxy_connect_tunnel(ngx_http_request_t *r,
     c = r->connection;
     u = ctx->u;
 
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
-                   "http proxy_connect, fu:%ui", from_upstream);
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http proxy_connect, fu:%ui write:%ui",
+                   from_upstream, do_write);
 
     downstream = c;
     upstream = u->peer.connection;


### PR DESCRIPTION
* Try to fixed https://github.com/chobits/ngx_http_proxy_connect_module/issues/9.
* ngx_http_proxy_connect_send_connection_established() has handled everything, even it can free request. ngx_http_proxy_connect_write_upstream should returns after calling ngx_http_proxy_connect_send_connection_established().
