### PR TITLE
docs: fix simple typo, successed -> succeeded

### DIFF
--- a/ngx_http_proxy_connect_module.c
+++ b/ngx_http_proxy_connect_module.c
@@ -69,7 +69,7 @@ struct ngx_http_proxy_connect_upstream_s {
 
     ngx_buf_t                                      buffer;
 
-    /* 1: DNS resolving successed */
+    /* 1: DNS resolving succeeded */
     ngx_flag_t                                     _resolved;
 
     /* 1: connection established */


### PR DESCRIPTION
There is a small typo in ngx_http_proxy_connect_module.c.

Should read `succeeded` rather than `successed`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md