### PR TITLE
fixed occasional failure of test cases in CI/CD workflow

### DIFF
--- a/t/http_proxy_connect.t
+++ b/t/http_proxy_connect.t
@@ -91,9 +91,9 @@ http {
     resolver 127.0.0.1:18085 ipv6=off;      # NOTE: cannot connect ipv6 address ::1 in mac os x.
 
     server {
-        listen  8081;
-        listen  8082;   # address.com
-        listen  8083;   # bind.conm
+        listen  127.0.0.1:8081;
+        listen  127.0.0.1:8082;   # address.com
+        listen  127.0.0.1:8083;   # bind.conm
         server_name server_8081;
         access_log off;
         location / {
@@ -118,11 +118,11 @@ http {
         proxy_connect_bind $proxy_local_address;
 
         if ($host = "address.com") {
-            set $proxy_remote_address "127.0.0.1:8082";
+            set $proxy_remote_address "127.0.0.01:8082";
         }
 
         if ($host = "bind.com") {
-            set $proxy_remote_address "127.0.0.1:8083";
+            set $proxy_remote_address "127.0.0.01:8083";
             set $proxy_local_address "127.0.0.1";   # NOTE that we cannot bind 127.0.0.3 in mac os x.
         }
 
@@ -131,7 +131,7 @@ http {
         }
 
         location / {
-            proxy_pass http://127.0.0.1:8081;
+            proxy_pass http://127.0.0.01:8081;
         }
 
         location = /hello {
@@ -219,7 +219,7 @@ http {
     access_log off;
 
     server {
-        listen  8082;
+        listen  127.0.0.1:8082;
         location / {
             return 200 "backend server: $remote_addr $server_port\n";
         }
@@ -234,7 +234,7 @@ http {
         proxy_connect;
         proxy_connect_allow all;
 
-        proxy_connect_address 127.0.0.1:8082;
+        proxy_connect_address 127.0.0.01:8082;
 
         if ($host = "if-return-skip.com") {
             return 200 "if-return\n";

--- a/t/http_proxy_connect_resolve_variables.t
+++ b/t/http_proxy_connect_resolve_variables.t
@@ -127,7 +127,7 @@ http {
         }
 
         location / {
-            proxy_pass http://127.0.0.1:8081;
+            proxy_pass http://127.0.0.01:8081;
         }
 
         # used to output connect.log

--- a/t/http_proxy_connect_timeout.t
+++ b/t/http_proxy_connect_timeout.t
@@ -119,7 +119,7 @@ http {
         }
 
         location / {
-            proxy_pass http://127.0.0.1:8081;
+            proxy_pass http://127.0.0.01:8081;
         }
 
         # used to output connect.log


### PR DESCRIPTION
use 127.0.0.01:8xxx instead 127.0.0.1:8xxx to skip port replace logic in Nginx.pm write_file_expand() function