### PR TITLE
refactor logic of handling proxy timer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,15 @@ jobs:
          sudo apt install -y libpcre3 libpcre3-dev
          sudo apt-get install libnet-dns-perl
          sudo cpan -T -i Test::More
+    - name: 'checkout luajit2'
+      uses: actions/checkout@v3
+      with:
+        repository: openresty/luajit2
+        path: luajit2
     - name: install luajit
+      working-directory: luajit2
       run: |
          pwd
-         wget https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz
-         tar xf LuaJIT-2.1.0-beta3.tar.gz
-         cd LuaJIT-2.1.0-beta3
          make -j
          sudo make install
          ls /usr/local/lib/ |grep lua

--- a/.github/workflows/test_nginx_lastest_commit.yml
+++ b/.github/workflows/test_nginx_lastest_commit.yml
@@ -22,12 +22,14 @@ jobs:
          sudo apt install -y libpcre3 libpcre3-dev
          sudo apt-get install libnet-dns-perl
          sudo cpan -T -i Test::More
+    - name: 'checkout luajit2'
+      uses: actions/checkout@v3
+      with:
+        repository: openresty/luajit2
+        path: luajit2
     - name: install luajit
+      working-directory: luajit2
       run: |
-         pwd
-         wget https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz
-         tar xf LuaJIT-2.1.0-beta3.tar.gz
-         cd LuaJIT-2.1.0-beta3
          make -j
          sudo make install
          ls /usr/local/lib/ |grep lua

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Table of Contents
       * [proxy_connect](#proxy_connect)
       * [proxy_connect_allow](#proxy_connect_allow)
       * [proxy_connect_connect_timeout](#proxy_connect_connect_timeout)
-      * [proxy_connect_read_timeout](#proxy_connect_read_timeout)
-      * [proxy_connect_send_timeout](#proxy_connect_send_timeout)
+      * [proxy_connect_data_timeout](#proxy_connect_data_timeout)
+      * [proxy_connect_read_timeout(deprecated)](#proxy_connect_read_timeout)
+      * [proxy_connect_send_timeout(deprecated)](#proxy_connect_send_timeout)
       * [proxy_connect_address](#proxy_connect_address)
       * [proxy_connect_bind](#proxy_connect_bind)
       * [proxy_connect_response](#proxy_connect_response)
@@ -34,8 +35,9 @@ Table of Contents
       * [$connect_port](#connect_port)
       * [$connect_addr](#connect_addr)
       * [$proxy_connect_connect_timeout](#proxy_connect_connect_timeout-1)
-      * [$proxy_connect_read_timeout](#proxy_connect_read_timeout-1)
-      * [$proxy_connect_send_timeout](#proxy_connect_send_timeout-1)
+      * [$proxy_connect_data_timeout](#proxy_connect_data_timeout-1)
+      * [$proxy_connect_read_timeout(deprecated)](#proxy_connect_read_timeout-1)
+      * [$proxy_connect_send_timeout(deprecated)](#proxy_connect_send_timeout-1)
       * [$proxy_connect_resolve_time](#proxy_connect_resolve_time)
       * [$proxy_connect_connect_time](#proxy_connect_connect_time)
       * [$proxy_connect_first_byte_time](#proxy_connect_first_byte_time)
@@ -67,8 +69,7 @@ Configuration Example
      proxy_connect;
      proxy_connect_allow            443 563;
      proxy_connect_connect_timeout  10s;
-     proxy_connect_read_timeout     10s;
-     proxy_connect_send_timeout     10s;
+     proxy_connect_data_timeout     10s;
 
      # forward proxy for non-CONNECT request
      location / {
@@ -329,6 +330,14 @@ Context: `server`
 
 Defines a timeout for establishing a connection with a proxied server.
 
+proxy_connect_data_timeout
+--------------------------
+
+Syntax: **proxy_connect_data_timeout `time`**  
+Default: `60s`  
+Context: `server`  
+
+Sets the timeout between two successive read or write operations on client or proxied server connections. If no data is transmitted within this time, the connection is closed.
 
 proxy_connect_read_timeout
 --------------------------
@@ -337,7 +346,9 @@ Syntax: **proxy_connect_read_timeout `time`**
 Default: `60s`  
 Context: `server`  
 
-Sets the timeout between two successive read or write operations on client or proxied server connections. If no data is transmitted within this time, the connection is closed.
+Deprecated.
+
+It has the same function as the directive `proxy_connect_data_timeout` for compatibility. You can configure only one of the directives (`proxy_connect_data_timeout` or `proxy_connect_read_timeout`).
 
 proxy_connect_send_timeout
 --------------------------
@@ -346,8 +357,9 @@ Syntax: **proxy_connect_send_timeout `time`**
 Default: `60s`  
 Context: `server`  
 
-Deprecated, it has no function.  
-Use the directive `proxy_connect_read_timeout` instead for both read and write operations.
+Deprecated.
+
+It has no function.
 
 proxy_connect_address
 ---------------------
@@ -450,27 +462,32 @@ For example:
 # Set default value
 
 proxy_connect_connect_timeout   10s;
-proxy_connect_read_timeout      10s;
-proxy_connect_send_timeout      10s;
+proxy_connect_data_timeout      10s;
 
 # Overlap default value
 
 if ($host = "test.com") {
     set $proxy_connect_connect_timeout  "10ms";
-    set $proxy_connect_read_timeout     "10ms";
-    set $proxy_connect_send_timeout     "10ms";
+    set $proxy_connect_data_timeout     "10ms";
 }
 ```
+
+$proxy_connect_data_timeout
+---------------------------
+
+Get or set a timeout of [`proxy_connect_data_timeout` directive](#proxy_connect_data_timeout).
 
 $proxy_connect_read_timeout
 ---------------------------
 
-Get or set a timeout of [`proxy_connect_read_timeout` directive](#proxy_connect_read_timeout).
+Deprecated. 
+It still can get or set a timeout of [`proxy_connect_data_timeout` directive](#proxy_connect_data_timeout) for compatibility.
 
 $proxy_connect_send_timeout
 ---------------------------
 
 Deprecated.
+It has no function.
 
 $proxy_connect_resolve_time
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -337,9 +337,7 @@ Syntax: **proxy_connect_read_timeout `time`**
 Default: `60s`  
 Context: `server`  
 
-Defines a timeout for reading a response from the proxied server.  
-The timeout is set only between two successive read operations, not for the transmission of the whole response.  
-If the proxied server does not transmit anything within this time, the connection is closed.
+Sets the timeout between two successive read or write operations on client or proxied server connections. If no data is transmitted within this time, the connection is closed.
 
 proxy_connect_send_timeout
 --------------------------
@@ -348,9 +346,8 @@ Syntax: **proxy_connect_send_timeout `time`**
 Default: `60s`  
 Context: `server`  
 
-Sets a timeout for transmitting a request to the proxied server.  
-The timeout is set only between two successive write operations, not for the transmission of the whole request.  
-If the proxied server does not receive anything within this time, the connection is closed.
+Deprecated, it has no function.  
+Use the directive `proxy_connect_read_timeout` instead for both read and write operations.
 
 proxy_connect_address
 ---------------------
@@ -473,7 +470,7 @@ Get or set a timeout of [`proxy_connect_read_timeout` directive](#proxy_connect_
 $proxy_connect_send_timeout
 ---------------------------
 
-Get or set a timeout of [`proxy_connect_send_timeout` directive](#proxy_connect_send_timeout).
+Deprecated.
 
 $proxy_connect_resolve_time
 ---------------------------

--- a/t/http_proxy_connect.t
+++ b/t/http_proxy_connect.t
@@ -111,8 +111,7 @@ http {
         proxy_connect;
         proxy_connect_allow 443 80 8081;
         proxy_connect_connect_timeout 10s;
-        proxy_connect_read_timeout 10s;
-        proxy_connect_send_lowat 0;
+        proxy_connect_data_timeout 10s;
         proxy_connect_address $proxy_remote_address;
         proxy_connect_bind $proxy_local_address;
 
@@ -614,7 +613,7 @@ sub start_bind {
         print "+ DNS server: working\n";
 
         END {
-            print("+ try to stop $bind_pid\n");
+            print("+ try to stop\n");
             stop_bind();
         }
     }

--- a/t/http_proxy_connect.t
+++ b/t/http_proxy_connect.t
@@ -112,7 +112,6 @@ http {
         proxy_connect_allow 443 80 8081;
         proxy_connect_connect_timeout 10s;
         proxy_connect_read_timeout 10s;
-        proxy_connect_send_timeout 10s;
         proxy_connect_send_lowat 0;
         proxy_connect_address $proxy_remote_address;
         proxy_connect_bind $proxy_local_address;

--- a/t/http_proxy_connect_resolve_variables.t
+++ b/t/http_proxy_connect_resolve_variables.t
@@ -106,11 +106,9 @@ http {
         proxy_connect_allow all;
         proxy_connect_connect_timeout 10s;
         proxy_connect_read_timeout 10s;
-        proxy_connect_send_timeout 10s;
         proxy_connect_send_lowat 0;
 
         set $proxy_connect_connect_timeout  "101ms";
-        set $proxy_connect_send_timeout     "102ms";
         set $proxy_connect_read_timeout     "103ms";
 
         if ($uri = "/200") {
@@ -123,7 +121,6 @@ http {
         if ($host = "test-read-timeout.com") {
             set $proxy_connect_connect_timeout  "3ms";
             set $proxy_connect_read_timeout     "1ms";
-            set $proxy_connect_send_timeout     "2ms";
         }
 
         if ($request ~ "127.0.0.1:8082") {

--- a/t/http_proxy_connect_resolve_variables.t
+++ b/t/http_proxy_connect_resolve_variables.t
@@ -105,10 +105,10 @@ http {
         proxy_connect;
         proxy_connect_allow all;
         proxy_connect_connect_timeout 10s;
-        proxy_connect_read_timeout 10s;
+        proxy_connect_data_timeout 10s;
 
         set $proxy_connect_connect_timeout  "101ms";
-        set $proxy_connect_read_timeout     "103ms";
+        set $proxy_connect_data_timeout     "103ms";
 
         if ($uri = "/200") {
             return 200;
@@ -119,27 +119,27 @@ http {
         }
         if ($host = "test-read-timeout.com") {
             set $proxy_connect_connect_timeout  "3ms";
-            set $proxy_connect_read_timeout     "1ms";
+            set $proxy_connect_data_timeout     "1ms";
         }
 
         if ($request ~ "127.0.0.1:8082") {
             # must be larger than 1s (server 8082 lua sleep(1s))
-            set $proxy_connect_read_timeout "1200ms";
+            set $proxy_connect_data_timeout "1200ms";
         }
 
         if ($request ~ "127.0.0.1:8083") {
             # must be larger than 0.5s (server 8082 lua sleep(0.5s))
-            set $proxy_connect_read_timeout "700ms";
+            set $proxy_connect_data_timeout "700ms";
         }
 
         if ($request ~ "127.0.0.01:8082") {
             # must be less than 1s (server 8082 lua sleep(1s))
-            set $proxy_connect_read_timeout "800ms";
+            set $proxy_connect_data_timeout "800ms";
         }
 
         if ($request ~ "127.0.0.01:8083") {
             # must be less than 0.5s (server 8082 lua sleep(1s))
-            set $proxy_connect_read_timeout "300ms";
+            set $proxy_connect_data_timeout "300ms";
         }
 
         location / {
@@ -419,7 +419,7 @@ sub start_bind {
         print "+ DNS server: working\n";
 
         END {
-            print("+ try to stop $bind_pid\n");
+            print("+ try to stop\n");
             stop_bind();
         }
     }

--- a/t/http_proxy_connect_resolve_variables.t
+++ b/t/http_proxy_connect_resolve_variables.t
@@ -106,7 +106,6 @@ http {
         proxy_connect_allow all;
         proxy_connect_connect_timeout 10s;
         proxy_connect_read_timeout 10s;
-        proxy_connect_send_lowat 0;
 
         set $proxy_connect_connect_timeout  "101ms";
         set $proxy_connect_read_timeout     "103ms";
@@ -158,6 +157,7 @@ http {
     server {
         access_log off;
         listen 8082;
+
         rewrite_by_lua '
             ngx.sleep(1)
             ngx.say("8082 server fbt")

--- a/t/http_proxy_connect_timeout.t
+++ b/t/http_proxy_connect_timeout.t
@@ -45,7 +45,7 @@ http {
 
     log_format connect '$remote_addr - $remote_user [$time_local] "$request" '
                        '$status $body_bytes_sent var:$connect_host-$connect_port-$connect_addr '
-                       ' c:$proxy_connect_connect_timeout,r:$proxy_connect_read_timeout';
+                       ' c:$proxy_connect_connect_timeout,r:$proxy_connect_data_timeout';
 
     access_log %%TESTDIR%%/connect.log connect;
     error_log %%TESTDIR%%/connect_error.log error;
@@ -60,17 +60,17 @@ http {
         proxy_connect;
         proxy_connect_allow all;
         proxy_connect_connect_timeout 10s;
-        proxy_connect_read_timeout 10s;
+        proxy_connect_data_timeout 10s;
 
         set $proxy_connect_connect_timeout  "101ms";
-        set $proxy_connect_read_timeout     "103ms";
+        set $proxy_connect_data_timeout     "103ms";
 
         if ($host = "test-connect-timeout.com") {
             set $proxy_connect_connect_timeout "1ms";
         }
         if ($host = "test-read-timeout.com") {
             set $proxy_connect_connect_timeout  "3ms";
-            set $proxy_connect_read_timeout     "1ms";
+            set $proxy_connect_data_timeout     "1ms";
         }
 
         location / {
@@ -140,7 +140,7 @@ http {
 
     log_format connect '$remote_addr - $remote_user [$time_local] "$request" '
                        '$status $body_bytes_sent var:$connect_host-$connect_port-$connect_addr '
-                       ' c:$proxy_connect_connect_timeout,r:$proxy_connect_read_timeout';
+                       ' c:$proxy_connect_connect_timeout,r:$proxy_connect_data_timeout';
 
     access_log %%TESTDIR%%/connect.log connect;
     error_log %%TESTDIR%%/connect_timeout_error.log debug;
@@ -155,12 +155,12 @@ http {
         proxy_connect;
         proxy_connect_allow all;
 
-        proxy_connect_read_timeout 10s;
+        proxy_connect_data_timeout 10s;
 
         proxy_connect_address "127.0.0.1:8081";
 
         if ($http_x_timeout) {
-            set $proxy_connect_read_timeout     $http_x_timeout;
+            set $proxy_connect_data_timeout     $http_x_timeout;
         }
 
         location / {
@@ -192,7 +192,7 @@ $t->waitforsocket('127.0.0.1:' . port(8081))
   or die "Can't start stream backend server";
 print("+ try to waitforsocket...done\n");
 
-# test time out of data proxying ( proxy_connect_read_timeout)
+# test time out of data proxying ( proxy_connect_data_timeout)
 my $str = '1234567890' x 10 . 'F';
 my $length = length($str);
 my $sport =  port(8081);

--- a/t/http_proxy_connect_timeout.t
+++ b/t/http_proxy_connect_timeout.t
@@ -25,7 +25,7 @@ use Net::DNS::Nameserver;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http proxy proxy_connect/)->plan(16);
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(16);
 
 ###############################################################################
 

--- a/t/http_proxy_connect_timeout.t
+++ b/t/http_proxy_connect_timeout.t
@@ -10,7 +10,9 @@ use warnings;
 use strict;
 
 use Test::More;
+use Time::HiRes;
 # use Test::Simple 'no_plan';
+use Test::Nginx::Stream qw/ stream /;
 
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
@@ -23,40 +25,7 @@ use Net::DNS::Nameserver;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http proxy/); #->plan(12);
-
-###############################################################################
-
-my $test_enable_rewrite_phase = 1;
-
-if (defined $ENV{TEST_DISABLE_REWRITE_PHASE}) {
-    $test_enable_rewrite_phase = 0;
-}
-
-print("+ test_enable_rewrite_phase: $test_enable_rewrite_phase\n");
-
-plan(skip_all => 'No rewrite phase enabled') if ($test_enable_rewrite_phase == 0);
-
-# --- init DNS server ---
-
-my $bind_pid;
-my $bind_server_port = 18085;
-
-# SRV record, not used
-my %route_map;
-
-# A record
-my %aroute_map = (
-    'test-connect-timeout.com' => [[300, "8.8.8.8"]],
-    'test-read-timeout.com' => [[300, "8.8.8.8"]],
-);
-
-# AAAA record (ipv6)
-my %aaaaroute_map;
-
-start_bind();
-
-# --- end ---
+my $t = Test::Nginx->new()->has(qw/http proxy proxy_connect/)->plan(16);
 
 ###############################################################################
 
@@ -81,7 +50,7 @@ http {
     access_log %%TESTDIR%%/connect.log connect;
     error_log %%TESTDIR%%/connect_error.log error;
 
-    resolver 127.0.0.1:18085 ipv6=off;      # NOTE: cannot connect ipv6 address ::1 in mac os x.
+    resolver 127.0.0.1:%%PORT_8981_UDP%% ipv6=off;      # NOTE: cannot connect ipv6 address ::1 in mac os x.
 
     server {
         listen       127.0.0.1:8080;
@@ -126,9 +95,9 @@ if ($@) {
     $t->run();
 }
 
-#if (not $test_enable_rewrite_phase) {
-#  exit
-#}
+$t->run_daemon(\&dns_daemon, port(8981), $t);
+$t->waitforfile($t->testdir . '/' . port(8981));
+
 
 TODO: {
     local $TODO = '# This case will pass, if connecting 8.8.8.8 timed out.';
@@ -149,16 +118,117 @@ like($t->read_file('connect.log'),
      'connect timed out log: get $var');
 like($t->read_file('connect.log'),
      qr/"CONNECT test-read-timeout.com:8888 HTTP\/1.1" ... .+ c:3,r:1/,
-     'connect/send/read timed out log: get $var');
+     'connect/read timed out log: get $var');
 
 $t->stop();
 
+###############################################################################
 
-# --- stop DNS server ---
+$nginx_conf = <<'EOF';
+%%TEST_GLOBALS%%
+daemon         off;
+events { }
 
-stop_bind();
+http {
+    %%TEST_GLOBALS_HTTP%%
 
-done_testing();
+    #LUA_PACKAGE_PATH
+    # If you build nginx with lua-nginx-module, please enable
+    # directive "lua_package_path". For more details, see:
+    #  https://github.com/openresty/lua-nginx-module#installation
+    #lua_package_path "/path/to/lib/lua/?.lua;;";
+
+    log_format connect '$remote_addr - $remote_user [$time_local] "$request" '
+                       '$status $body_bytes_sent var:$connect_host-$connect_port-$connect_addr '
+                       ' c:$proxy_connect_connect_timeout,r:$proxy_connect_read_timeout';
+
+    access_log %%TESTDIR%%/connect.log connect;
+    error_log %%TESTDIR%%/connect_timeout_error.log debug;
+
+    resolver 127.0.0.1:18085 ipv6=off;      # NOTE: cannot connect ipv6 address ::1 in mac os x.
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        # forward proxy for CONNECT method
+        proxy_connect;
+        proxy_connect_allow all;
+
+        proxy_connect_read_timeout 10s;
+
+        proxy_connect_address "127.0.0.1:8081";
+
+        if ($http_x_timeout) {
+            set $proxy_connect_read_timeout     $http_x_timeout;
+        }
+
+        location / {
+            proxy_pass http://127.0.0.1:8081;
+        }
+    }
+}
+
+EOF
+
+$t->write_file_expand('nginx.conf', $nginx_conf);
+
+$t->run_daemon(\&stream_daemon);
+
+eval {
+    $t->run();
+};
+
+if ($@) {
+    print("+ Retry new nginx conf: remove \"ipv6=off\"\n");
+
+    $nginx_conf =~ s/ ipv6=off;/;/g;        # remove ipv6=off in resolver directive.
+    $t->write_file_expand('nginx.conf', $nginx_conf);
+    $t->run();
+}
+
+print("+ try to waitforsocket...\n");
+$t->waitforsocket('127.0.0.1:' . port(8081))
+  or die "Can't start stream backend server";
+print("+ try to waitforsocket...done\n");
+
+# test time out of data proxying ( proxy_connect_read_timeout)
+my $str = '1234567890' x 10 . 'F';
+my $length = length($str);
+my $sport =  port(8081);
+my $s;
+
+# test: timeout expired or not
+
+$s = stream('127.0.0.1:' . port(8080));
+
+like($s->io(<<EOF, read_timeout => 0.5), qr/200 Connection Established/, "establish CONNECT tunnel");
+CONNECT 127.0.0.1:$sport HTTP/1.1
+Host: stream
+X-Timeout: 1000ms
+
+EOF
+
+my $i;
+for ($i = 0; $i < 8; $i++) {
+    my $ms = $i/10;
+    Time::HiRes::sleep($ms);    # < timeout
+    is($s->io($str, length => $length), $str,
+       "timeout not expired, then sleep $ms s");
+}
+
+# check log
+#2022/11/29 13:49:28 [info] 1746#0: *3 proxy_connect: connection timed out (110: Connection timed out) while proxying connection, client: 127.0.0.1, server: localhost, request: "CONNECT 127.0.0.1:8081 HTTP/1.1", host: "stream"
+unlike($t->read_file('connect_timeout_error.log'),
+     qr/proxy_connect: connection timed out .* "CONNECT .*", host: "stream"/,
+     'get log: not timed out');
+
+Time::HiRes::sleep(1.2);    # > timeout
+like($t->read_file('connect_timeout_error.log'),
+     qr/proxy_connect: connection timed out .* "CONNECT .*", host: "stream"/,
+     'get log: timed out');
+
+$t->stop();
 
 ###############################################################################
 
@@ -217,108 +287,162 @@ EOF
 # --- DNS Server ---
 
 sub reply_handler {
-    my ($qname, $qclass, $qtype, $peerhost, $query, $conn) = @_;
-    my ($rcode, @ans, @auth, @add);
-    # print("DNS reply: receive query=$qname, $qclass, $qtype, $peerhost, $query, $conn\n");
+	my ($recv_data, $port, $state) = @_;
 
-    if ($qtype eq "SRV" && exists($route_map{$qname})) {
-        my @records = @{$route_map{$qname}};
-        for (my $i = 0; $i < scalar(@records); $i++) {
-            my ($ttl, $weight, $priority, $port, $origin_addr) = @{$records[$i]};
-            my $rr = new Net::DNS::RR("$qname $ttl $qclass $qtype $priority $weight $port $origin_addr");
-            push @ans, $rr;
-            # print("DNS reply: $qname $ttl $qclass $qtype $origin_addr\n");
-        }
+	my (@name, @rdata);
 
-        $rcode = "NOERROR";
-    } elsif (($qtype eq "A") && exists($aroute_map{$qname})) {
-        my @records = @{$aroute_map{$qname}};
-        for (my $i = 0; $i < scalar(@records); $i++) {
-            my ($ttl, $origin_addr) = @{$records[$i]};
-            my $rr = new Net::DNS::RR("$qname $ttl $qclass $qtype $origin_addr");
-            push @ans, $rr;
-            # print("DNS reply: $qname $ttl $qclass $qtype $origin_addr\n");
-        }
+	use constant NOERROR	=> 0;
+	use constant SERVFAIL	=> 2;
+	use constant NXDOMAIN	=> 3;
 
-        $rcode = "NOERROR";
-    } elsif (($qtype eq "AAAA") && exists($aaaaroute_map{$qname})) {
-        my @records = @{$aaaaroute_map{$qname}};
-        for (my $i = 0; $i < scalar(@records); $i++) {
-            my ($ttl, $origin_addr) = @{$records[$i]};
-            my $rr = new Net::DNS::RR("$qname $ttl $qclass $qtype $origin_addr");
-            push @ans, $rr;
-            # print("DNS reply: $qname $ttl $qclass $qtype $origin_addr\n");
-        }
+	use constant A		=> 1;
+	use constant CNAME	=> 5;
+	use constant AAAA	=> 28;
+	use constant DNAME	=> 39;
 
-        $rcode = "NOERROR";
-    } else {
-        $rcode = "NXDOMAIN";
-    }
+	use constant IN		=> 1;
 
-    # mark the answer as authoritative (by setting the 'aa' flag)
-    my $headermask = { ra => 1 };
+	# default values
 
-    # specify EDNS options  { option => value }
-    my $optionmask = { };
+	my ($hdr, $rcode, $ttl) = (0x8180, NOERROR, 3600);
 
-    return ($rcode, \@ans, \@auth, \@add, $headermask, $optionmask);
+	# decode name
+
+	my ($len, $offset) = (undef, 12);
+	while (1) {
+		$len = unpack("\@$offset C", $recv_data);
+		last if $len == 0;
+		$offset++;
+		push @name, unpack("\@$offset A$len", $recv_data);
+		$offset += $len;
+	}
+
+	$offset -= 1;
+	my ($id, $type, $class) = unpack("n x$offset n2", $recv_data);
+
+	my $name = join('.', @name);
+
+	if (($name eq 'test-connect-timeout.com') || 
+            ($name eq 'test-read-timeout.com')) 
+        {
+		if ($type == A) {
+			push @rdata, rd_addr($ttl, '8.8.8.8');
+		}
+	}
+
+	$len = @name;
+	pack("n6 (C/a*)$len x n2", $id, $hdr | $rcode, 1, scalar @rdata,
+		0, 0, @name, $type, $class) . join('', @rdata);
 }
 
-sub bind_daemon {
-    my $ns = new Net::DNS::Nameserver(
-        LocalAddr        => ['127.0.0.1'],
-        LocalPort        => $bind_server_port,
-        ReplyHandler     => \&reply_handler,
-        Verbose          => 0, # Verbose = 1 to print debug info
-        Truncate         => 0
-    ) || die "[D] DNS server: couldn't create nameserver object\n";
+sub rd_addr {
+	my ($ttl, $addr) = @_;
 
-    $ns->main_loop;
+	my $code = 'split(/\./, $addr)';
+
+	pack 'n3N nC4', 0xc00c, A, IN, $ttl, eval "scalar $code", eval($code);
 }
 
-sub start_bind {
-    if (defined $bind_server_port) {
+sub expand_ip6 {
+	my ($addr) = @_;
 
-        print "+ DNS server: try to bind server port: $bind_server_port\n";
-
-        $t->run_daemon(\&bind_daemon);
-        $bind_pid = pop @{$t->{_daemons}};
-
-        print "+ DNS server: daemon pid: $bind_pid\n";
-
-        my $s;
-        my $i = 1;
-        while (not $s) {
-            $s = IO::Socket::INET->new(
-                 Proto    => 'tcp',
-                 PeerAddr => "127.0.0.1",
-                 PeerPort => $bind_server_port
-            );
-            sleep 0.1;
-            $i++ > 20 and last;
-        }
-        sleep 0.1;
-        $s or die "cannot connect to DNS server";
-        close($s) or die 'can not connect to DNS server';
-
-        print "+ DNS server: working\n";
-
-        END {
-            print("+ try to stop $bind_pid\n");
-            stop_bind();
-        }
-    }
+	substr ($addr, index($addr, "::"), 2) =
+		join "0", map { ":" } (0 .. 8 - (split /:/, $addr) + 1);
+	map { hex "0" x (4 - length $_) . "$_" } split /:/, $addr;
 }
 
-sub stop_bind {
-    if (defined $bind_pid) {
-        # kill dns daemon
-        kill $^O eq 'MSWin32' ? 15 : 'TERM', $bind_pid;
-        wait;
+sub rd_addr6 {
+	my ($ttl, $addr) = @_;
 
-        $bind_pid = undef;
-        print ("+ DNS server: stop\n");
-    }
+	pack 'n3N nn8', 0xc00c, AAAA, IN, $ttl, 16, expand_ip6($addr);
 }
 
-###############################################################################
+sub dns_daemon {
+	my ($port, $t) = @_;
+
+	my ($data, $recv_data);
+	my $socket = IO::Socket::INET->new(
+		LocalAddr => '127.0.0.1',
+		LocalPort => $port,
+		Proto => 'udp',
+	)
+		or die "Can't create listening socket: $!\n";
+
+	# track number of relevant queries
+
+	my %state = (
+		cnamecnt	=> 0,
+		twocnt		=> 0,
+		manycnt		=> 0,
+	);
+
+	# signal we are ready
+
+	open my $fh, '>', $t->testdir() . '/' . $port;
+	close $fh;
+
+	while (1) {
+		$socket->recv($recv_data, 65536);
+		$data = reply_handler($recv_data, $port, \%state);
+		$socket->send($data);
+	}
+}
+
+################################################################################
+
+sub stream_daemon {
+	my $server = IO::Socket::INET->new(
+		Proto => 'tcp',
+		LocalAddr => '127.0.0.1:' . port(8081),
+		Listen => 5,
+		Reuse => 1
+	)
+		or die "Can't create listening socket: $!\n";
+
+        print("+ stream daemon started.\n");
+
+	my $sel = IO::Select->new($server);
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	while (my @ready = $sel->can_read) {
+		foreach my $fh (@ready) {
+			if ($server == $fh) {
+				my $new = $fh->accept;
+				$new->autoflush(1);
+				$sel->add($new);
+
+			} elsif (stream_handle_client($fh)) {
+				$sel->remove($fh);
+				$fh->close;
+			}
+		}
+	}
+}
+
+sub stream_handle_client {
+	my ($client) = @_;
+
+	log2c("(new connection $client)");
+
+	$client->sysread(my $buffer, 65536) or return 1;
+
+        log2i("$client $buffer");
+        $client->syswrite($buffer);
+        return 0;
+
+        log2i("$client $buffer");
+
+	my $close = $buffer =~ /F/;
+
+	log2o("$client $buffer");
+
+	$client->syswrite($buffer);
+
+	return $close;
+}
+
+sub log2i { Test::Nginx::log_core('|| <<', @_); }
+sub log2o { Test::Nginx::log_core('|| >>', @_); }
+sub log2c { Test::Nginx::log_core('||', @_); }
+##############################################################################


### PR DESCRIPTION
# directive modifed

proxy_connect_data_timeout
--------------------------

Syntax: **proxy_connect_data_timeout `time`**
Default: `60s`
Context: `server`

Sets the timeout between two successive read or write operations on client or proxied server connections. If no data is transmitted within this time, the connection is closed.

 proxy_connect_read_timeout
 --------------------------
~~Defines a timeout for reading a response from the proxied server.
The timeout is set only between two successive read operations, not for the transmission of the whole response.
If the proxied server does not transmit anything within this time, the connection is closed.~~

Deprecated.

It has the same function as the directive `proxy_connect_data_timeout` for compatibility. You can configure only one of the directives (`proxy_connect_data_timeout` or `proxy_connect_read_timeout`).

 proxy_connect_send_timeout
 --------------------------
~~Sets a timeout for transmitting a request to the proxied server.
The timeout is set only between two successive write operations, not for the transmission of the whole request.
If the proxied server does not receive anything within this time, the connection is closed.~~

Deprecated, it has no function.

# patch
1. Refactor timer logic in ngx_http_proxy_connect_tunnel(), refer to ngx_stream_proxy_process() in ngx_stream_proxy_module. Now it only adds one timer after it processes r/w operations on client or proxied server connections.
3. With the new timer logic, it will fix connection break that it continues to upload data to backend (Try to fix https://github.com/chobits/ngx_http_proxy_connect_module/issues/175)
4. Added new test cases and documentation for new timer logic
5. Added new directive `proxy_connect_data_timeout`


* ~~todo: test case to upload long data flow  to proxied server~~ (see http_proxy_connect_timeout.t)