### PR TITLE
make it return the same status code as nginx does to refuse CONNECT method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
          pwd
          git clone https://github.com/openresty/lua-resty-core.git
          cd lua-resty-core
+         git checkout d2179dbcb3d6d77127462cadd40cca103d89a52a
          sudo make install PREFIX=/opt/nginx
          cd ..
          git clone https://github.com/openresty/lua-resty-lrucache.git

--- a/.github/workflows/test_nginx_lastest_commit.yml
+++ b/.github/workflows/test_nginx_lastest_commit.yml
@@ -57,6 +57,7 @@ jobs:
          pwd
          git clone https://github.com/openresty/lua-resty-core.git
          cd lua-resty-core
+         git checkout d2179dbcb3d6d77127462cadd40cca103d89a52a
          sudo make install PREFIX=/opt/nginx
          cd ..
          git clone https://github.com/openresty/lua-resty-lrucache.git

--- a/ngx_http_proxy_connect_module.c
+++ b/ngx_http_proxy_connect_module.c
@@ -2342,7 +2342,7 @@ ngx_http_proxy_connect_post_read_handler(ngx_http_request_t *r)
         if (!pclcf->accept_connect) {
             ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                           "proxy_connect: client sent connect method");
-            return NGX_HTTP_BAD_REQUEST;
+            return NGX_HTTP_NOT_ALLOWED;
         }
 
         /* init ctx */

--- a/t/http_proxy_connect.t
+++ b/t/http_proxy_connect.t
@@ -176,7 +176,7 @@ like(http_connect_request('www.no-dns-reply.com', '80', '/'), qr/502/, '200 Conn
 like(http_connect_request('127.0.0.1', '9999', '/'), qr/403/, '200 Connection Established not allowed port');
 like(http_get('/'), qr/backend server/, 'Get method: proxy_pass');
 like(http_get('/hello'), qr/world/, 'Get method: return 200');
-like(http_connect_request('forbidden.example.com', '8080', '/'), qr/400 Bad Request/, 'forbid CONNECT request without proxy_connect command enabled');
+like(http_connect_request('forbidden.example.com', '8080', '/'), qr/405 Not Allowed/, 'forbid CONNECT request without proxy_connect command enabled');
 
 # proxy_remote_address directive supports dynamic domain resolving.
 like(http_connect_request('proxy-remote-address-resolve-domain.com', '8081', '/'),


### PR DESCRIPTION
If proxy_connect module is not enabled, the server will return a 405 status code instead of 400.