### PR TITLE
fixed compilation error on clang

### DIFF
--- a/ngx_http_proxy_connect_module.c
+++ b/ngx_http_proxy_connect_module.c
@@ -667,7 +667,6 @@ ngx_http_proxy_connect_tunnel(ngx_http_request_t *r,
                    "proxy_connect: tunnel fu:%ui write:%ui",
                    from_upstream, do_write);
 
-    c = c;
     pc = u->peer.connection;
 
     if (from_upstream) {


### PR DESCRIPTION
reported by tengine workflow: https://github.com/alibaba/tengine/actions/runs/4123992863/jobs/7122697530

```
clang -c -I/usr/local/include/luajit-2.1  -pipe  -O -Wall -Wextra -Wpointer-arith -Wconditional-uninitialized -Wno-unused-parameter -Werror -g -D T_NGX_MODIFY_DEFAULT_VALUE=0 -D T_NGX_HTTP_IMAGE_FILTER=0 -D T_NGX_SERVER_INFO=0 -DNDK_SET_VAR  -I src/core -I src/event -I src/event/modules -I src/os/unix -I src/proc -I modules/ngx_http_lua_module/src/api -I modules/ngx_http_upstream_check_module -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/http/modules/perl -I modules/mod_dubbo -I modules/mod_dubbo/utils -I modules/mod_dubbo/hessian2 -I /usr/local/include/luajit-2.1 -I modules/ngx_multi_upstream_module -I modules/ngx_http_upstream_dyups_module -I src/mail -I src/stream -I modules/ngx_multi_upstream_module \
	-o objs/addon/ngx_http_reqstat_module/ngx_http_reqstat_module.o \
	modules/ngx_http_reqstat_module/ngx_http_reqstat_module.c
modules/ngx_http_proxy_connect_module/ngx_http_proxy_connect_module.c:670:7: error: explicitly assigning value of variable of type 'ngx_connection_t *' (aka 'struct ngx_connection_s *') to itself [-Werror,-Wself-assign]
    c = c;
    ~ ^ ~
1 error generated.
```