### PR TITLE
ci.yml: trigger workflow for new mainlain version nginx-1.23.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test-nginx:
     strategy:
        matrix:
-         version: [1.22.1, 1.23.2]
+         version: [1.22.1, 1.23.3]
        fail-fast: false
     runs-on: "ubuntu-20.04"
 


### PR DESCRIPTION
nginx-1.23.3  mainlain version has been released on December 13, 2022. This pr will trigger workflow to test it.