### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please disclose it at [security advisory](https://github.com/chobits/ngx_http_proxy_connect_module/security/advisories/new).
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, please give us at least 90 days to work on a fix before public exposure.


### PR DESCRIPTION
I've created the SECURITY.md file considering the report vulnerability through security advisory, which is a new GitHub feature.

If you're interested in GitHub's feature, it must be activated for the repository:

1. Open the repo's Settings
2. Click on Advanced Security
3. Click "Enable" for "Private vulnerability reporting"

If you rather not enable it, there is also the possibility to receive the vulnerability report through an email. Besides that, feel free to edit or suggest any changes to this document. It is supposed to reflect the amount of effort the team can offer to handle vulnerabilities.